### PR TITLE
Updating slurm.conf to set the maxForks and the default time

### DIFF
--- a/conf/slurm.config
+++ b/conf/slurm.config
@@ -20,12 +20,12 @@
 process {
     executor = 'slurm'
     clusterOptions = '--job-name=nxf_test --account=nn9305k --mem-per-cpu=3140'
-    maxForks = 128
+    maxForks = 64
     maxRetries = 3
     errorStrategy='retry'
 
     cpus = 16
 
-    time = { 1.h * task.attempt }
+    time = { 30.m * task.attempt }
     withName: run_spadesasm {time = { 4.h * task.attempt }}
 }


### PR DESCRIPTION
to something that abel/nextflow can handle.