### PR TITLE
Solves NVI BIFROST issue 15

### DIFF
--- a/asm_annot.nf
+++ b/asm_annot.nf
@@ -281,6 +281,6 @@ process quast_eval {
     ${preCmd}
     quast --threads $task.cpus -o quast_evaluation_all \
     -G ${params.quast_genes} -R ${params.quast_ref} \
-    ${asm_list} \
+    --scaffolds ${asm_list}
     """
 }


### PR DESCRIPTION
Added --scaffolds to quast command to ensure that we also check
how the asm is if we break up scaffolds.