### PR TITLE
Enables the use of locally downloaded databases

### DIFF
--- a/conf/specific_genes_template.config
+++ b/conf/specific_genes_template.config
@@ -22,18 +22,17 @@ params.threads = 1
 // Ariba mlst params
 params.do_mlst = "yes"
 //params.mlst_scheme = "Escherichia coli#1"
-params.mlst_scheme = "Campylobacter jejuni"
+params.mlst_db = "/cluster/projects/nn9305k/db_flatfiles/specific_genes_bifrost/mlst/Escherichia_coli_1_db"
 params.mlst_results = "mlst_results"
-
 
 // Ariba AMR params
 // Check the ariba webpage for legal values
 params.do_amr = "yes"
-params.amr_db = "card"
+params.amr_db = "/cluster/projects/nn9305k/db_flatfiles/specific_genes_bifrost/amr/card_db"
 params.amr_results = "amr_results"
 
 // Ariba virulence params
 // Check the ariba webpage for legal values
 params.do_vir = "yes"
-params.vir_db = "vfdb_core"
+params.vir_db = "/cluster/projects/nn9305k/db_flatfiles/specific_genes_bifrost/vir/virulencefinder_db"
 params.vir_results = "vir_results"


### PR DESCRIPTION
This commit fixes the issue with databases not being downloadable from
the internet anymore on saga. To fix, I have set it up so that the
results from ariba getref/prepareref and pubmlstget can be used directly
by specifying the path to the resulting directories.