### PR TITLE
Fixes Issue 45 with regards to reuse of database with multiple datasets.

### DIFF
--- a/conf/specific_genes_template.config
+++ b/conf/specific_genes_template.config
@@ -19,6 +19,8 @@ params.savemode = "copy"
 
 params.threads = 1
 
+// Databases need to be preloaded into the directories specified below.
+
 // Ariba mlst params
 params.do_mlst = "yes"
 //params.mlst_scheme = "Escherichia coli#1"
@@ -26,13 +28,11 @@ params.mlst_db = "/cluster/projects/nn9305k/db_flatfiles/specific_genes_bifrost/
 params.mlst_results = "mlst_results"
 
 // Ariba AMR params
-// Check the ariba webpage for legal values
 params.do_amr = "yes"
 params.amr_db = "/cluster/projects/nn9305k/db_flatfiles/specific_genes_bifrost/amr/card_db"
 params.amr_results = "amr_results"
 
 // Ariba virulence params
-// Check the ariba webpage for legal values
 params.do_vir = "yes"
 params.vir_db = "/cluster/projects/nn9305k/db_flatfiles/specific_genes_bifrost/vir/virulencefinder_db"
 params.vir_results = "vir_results"


### PR DESCRIPTION
This commit fixes what was tried to be fixed in Issue 44. In this case,
the situation is that Saga no longer allows for internet access on the
compute nodes. This means that we cannot download data within a slurm job.
Thus we have to preload the databases somewhere, and use those. This
commit sets up provisions for using a database that is preloaded on saga.

Closes #45 